### PR TITLE
Reference static property, well, statically.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -101,7 +101,7 @@ class Plugin_Disqus extends Plugin{
 	public function show($script_only = false){
 		
 		// if we've already included the script, don't do it again
-		if ($this->included) {
+		if (static::$included) {
 			return;
 		}
 
@@ -198,7 +198,7 @@ class Plugin_Disqus extends Plugin{
 			");
 		}
 		
-		$this->included = true;
+		static::$included = true;
 		
 		return $str;
 	}


### PR DESCRIPTION
Currently, with strict reporting enabled, a notice is being thrown for a rather simple oversight, that you've got a static property, `$included`, but you are referencing it as an object instance property.

![screen shot 2013-09-19 at 9 58 40 am](https://f.cloud.github.com/assets/181919/1169839/79ae3ac0-20be-11e3-9d92-197d11b563ce.png)
